### PR TITLE
Enable JSON Beautifier when JSON type is stated, but not inferred

### DIFF
--- a/burp/BurpExtender.java
+++ b/burp/BurpExtender.java
@@ -161,7 +161,7 @@ public class BurpExtender implements IBurpExtender, IMessageEditorTabFactory, IT
                 return requestInfo.getContentType() == IRequestInfo.CONTENT_TYPE_JSON;
             } else {
                 responseInfo = helpers.analyzeResponse(content);
-                return responseInfo.getInferredMimeType().equals("JSON");
+                return responseInfo.getInferredMimeType().equals("JSON") || responseInfo.getStatedMimeType().equals("JSON");
             }
         }
 


### PR DESCRIPTION
I have a few examples of JSON responses, where the JSON content-type is stated and displayed as such in Burp Proxy "MIME Type" column, and where the JSON content is also valid, but where JSON Beautifier tab is missing.
After a quick debugging session I see that the stated MIME type is indeed JSON, but the inferred MIME type (by Burp) is empty... It could be a Burp issue too.
This PR enables JSON Beautifier tab if either (stated/inferred) is JSON.

I'm using Burp Pro, latest version (2.1.05)